### PR TITLE
Adding ssl policy block to application gateway

### DIFF
--- a/examples/application-gateway-with-https-configuration/main.tf
+++ b/examples/application-gateway-with-https-configuration/main.tf
@@ -69,7 +69,7 @@ module "application_gateway" {
     frontend_ip_configuration = "Public"
     protocol                  = "Https"
     port                      = 443
-    certificate_name          = "certificate"
+    ssl_certificate_name          = "certificate"
   }]
   backend_http_settings = [{
     name     = "backend-http-setting"
@@ -82,5 +82,9 @@ module "application_gateway" {
     http_listener_name         = "http-listener"
     backend_address_pool_name  = "backend-address-pool"
     backend_http_settings_name = "backend-http-setting"
+  }]
+  ssl_policies = [{
+    policy_type = "Predefined"
+    predefined_policy_name = "AppGwSslPolicy20170401S"
   }]
 }

--- a/main.tf
+++ b/main.tf
@@ -137,4 +137,15 @@ resource "azurerm_application_gateway" "main" {
       backend_http_settings_name = request_routing_rule.value.backend_http_settings_name
     }
   }
+
+  dynamic "ssl_policy" {
+    for_each = var.ssl_policies
+
+    content {
+      policy_type          = ssl_policy.value.policy_type
+      policy_name          = lookup(ssl_policy.value, "predefined_policy_name", null)
+      min_protocol_version = lookup(ssl_policy.value, "min_protocol_version", null)
+      cipher_suites        = lookup(ssl_policy.value, "cipher_suites", null)
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -307,3 +307,14 @@ variable "request_routing_rules" {
     error_message = "The backend_http_settings_name must be one of the defined backend http settings."
   }
 }
+
+variable "ssl_policies" {
+  description = "List of SSL policies for the Application Gateway"
+  type = list(object({
+    policy_type            = string
+    predefined_policy_name = optional(string)
+    min_protocol_version   = optional(string)
+    cipher_suites          = optional(list(string))
+  }))
+  default = []
+}


### PR DESCRIPTION
We used and tested the module internally. 

CR#1
To meet our security and compliance standards, we need ssl policy block to define ssl policies for application gateway, hence added the same, following the dynamic and flexible approach of this module.

CR#2
We noticed that one of the key of variable **http_listeners** is defined differently inside module, which is causing an issue.
The attribute is named **ssl_certificate_name** in **variables.tf** and **certificate_name** inside the module **(application gateway with https configuration)**
Hence, we have replaced certificate_name with ssl_certificate_name in the module.

Please review the changes and merge the same as soon as possible. As we want to make use of this module internally.
Awaiting your response.